### PR TITLE
Use an incrementing counter for the RPC request id

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ class LightningClient {
         this.rpcPath = rpcPath;
         this.reconnectWait = 0.5;
         this.reconnectTimeout = null;
+        this.reqcount = 0;
 
         const _self = this;
 
@@ -122,7 +123,7 @@ class LightningClient {
 
         const _self = this;
 
-        const callInt = Math.round(Math.random() * 10000);
+        const callInt = ++this.reqcount;
         const sendObj = {
             method,
             params: args,


### PR DESCRIPTION
Using random numbers, especially in such [a small range](https://github.com/BHBNETWORK/lightning-client-js/blob/b0a1b023942e139f37150880427bc717c77e9c12/index.js#L125), is prone to conflicting requests with one another. Using a counter better ensures uniqueness.