### PR TITLE
Add a "debugFlag" to show real stacktraces when errors occur

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,19 @@ Once the client is installed you can use it by loading the main class and instan
 
 const LightningClient = require('lightning-client');
 
-// This should point to your lightning-dir, by default in ~/.lightning
-const client = new LightningClient('/home/bitcoind/.lightning');
+// This should point to your lightning-dir, by default in ~/.lightning. 
+// The debug mode is enabled (second parameter) but this decreases performances (see PR #10)
+const client = new LightningClient('/home/bitcoind/.lightning', true);
 
 // Every call returns a Promise
 
 // "Show information about this node"
 client.getinfo()
 	.then(info => console.log(info))
-	.catch(err => console.log(err.message));
+	.catch(err => console.log(err));
 
 // "Create an invoice for {msatoshi} with {label} and {description} with optional {expiry} seconds (default 1 hour)" }
 client.invoice(100, 'my-label-4', 'my-description-4', 3600)
 	.then(result => console.log(result))
-	.catch(err => console.log(err.message));
+	.catch(err => console.log(err));
 ```

--- a/example.js
+++ b/example.js
@@ -2,7 +2,8 @@
 
 const LightningClient = require('lightning-client');
 
-// This should point to your lightning-dir, by default in ~/.lightning
+// This should point to your lightning-dir, by default in ~/.lightning.
+// The debug mode is enabled (second parameter) but this decreases performances (see PR #10)
 const client = new LightningClient('/home/bitcoind/.lightning', true);
 
 // Every call returns a Promise

--- a/example.js
+++ b/example.js
@@ -3,16 +3,16 @@
 const LightningClient = require('lightning-client');
 
 // This should point to your lightning-dir, by default in ~/.lightning
-const client = new LightningClient('/home/bitcoind/.lightning');
+const client = new LightningClient('/home/bitcoind/.lightning', true);
 
 // Every call returns a Promise
 
 // "Show information about this node"
 client.getinfo()
 	.then(info => console.log(info))
-	.catch(err => console.log(err.message));
+	.catch(err => console.log(err));
 
 // "Create an invoice for {msatoshi} with {label} and {description} with optional {expiry} seconds (default 1 hour)" }
 client.invoice(100, 'my-label-4', 'my-description-4', 3600)
 	.then(result => console.log(result))
-	.catch(err => console.log(err.message));
+	.catch(err => console.log(err));

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const _ = require('lodash');
 const methods = require('./methods');
 
 class LightningClient extends EventEmitter {
-    constructor(rpcPath) {
+    constructor(rpcPath, debugFlag = false) {
         if (!path.isAbsolute(rpcPath)) {
             throw new Error('The rpcPath must be an absolute path');
         }
@@ -22,6 +22,8 @@ class LightningClient extends EventEmitter {
         this.reconnectWait = 0.5;
         this.reconnectTimeout = null;
         this.reqcount = 0;
+
+        this.debug = debugFlag;
 
         const _self = this;
 
@@ -118,6 +120,12 @@ class LightningClient extends EventEmitter {
             return Promise.reject(new Error('invalid_call'));
         }
 
+        let stackTrace = null;
+        if (this.debug === true) { // not really efficient, we skip this step if debug is not enabled
+            const error = new Error();
+            stackTrace = error.stack;
+        }
+
         const _self = this;
 
         const callInt = ++this.reqcount;
@@ -137,7 +145,7 @@ class LightningClient extends EventEmitter {
                         return;
                     }
 
-                    reject(new Error(JSON.stringify(response.error)));
+                    reject({error: response.error, stack: stackTrace});
                 });
 
                 // Send the command


### PR DESCRIPTION
Add a flag to enable "debug mode" that shows real stack traces when errors occur.

This is not enabled by default because building the stack trace is not really efficient and most of the time it would be useless (if the call is resolved without errors).